### PR TITLE
Remove additional bias from the die throw whith ISAAC CRNG

### DIFF
--- a/js/dicepass.js
+++ b/js/dicepass.js
@@ -37,11 +37,11 @@ var DicePass = {
       // but this won't be cryptographically sound.
       numbers = new Array();
       for (var i = 0; i < this.DEFAULT_WORD_COUNT; i++) {
-        var v = isaac.rand();
-        if (v < 0) {
-          v = v * -1;
+        numbers.push(Math.abs(isaac.rand())); // range: [0, 2147483648]
+        // 2147483648 is not divisible by 6, so force a range that is:
+        while(numbers[i] >= 2147483646) {
+          numbers[i] = Math.abs(isaac.rand());
         }
-        numbers.push(v);
       }
     }
     return numbers;


### PR DESCRIPTION
I just noticed that the isaac.js CRNG was also biased for browsers that did not
support the Web Crypto API. The ISAAC CRNG generates a 32-bit number from:

    -2147483648 <= n <= 2147483647

The prior code forced positive numbers in the range of:

    0 <= n <= 2147483648

Which has a range of 2147483649 numbers, which is not divisible by 6 (the
number of faces on a die for the dice throw). This code forces the range into:

    0 <= n <= 2147483645

Which has a range of 2147483646 numbers, which is 357913941*6. Thus, every face
on the dice is equally as likely to toss up as the other.

Also cleaned up a bit of the code using Math.abs() and eliminating a variable
assignment.