### PR TITLE
Add subresource integrity.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap-theme.min.css" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" crossorigin="anonymous">
-        <link rel="stylesheet" href="css/main.css" crossorigin="anonymous">
+        <link rel="stylesheet" href="css/main.css" integrity="sha256-r8wwMeDu+I+CUvMn/pXP+PYj/S0uBolHwjEWEZzBkYI=" crossorigin="anonymous">
 
         <meta property="og:title" content="DicePass - Secure Random Passphrase Generator" />
         <meta property="og:description" content="Secure random passphrase Generator based on EFF.org's Dice" />
@@ -109,9 +109,9 @@
 
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
       <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-      <script type="text/javascript" src="./js/eff_large_wordlist.js"></script>
-      <script type="text/javascript" src="./js/dicepass.js"></script>
-      <script type="text/javascript" src="./js/vendor/isaac.js"></script>
-      <script type="text/javascript" src="./js/main.js"></script>
+      <script type="text/javascript" src="./js/eff_large_wordlist.js" integrity="sha256-nyRzE2IvapTJUvtN3mcfayefe9d4ImABu8tcAAQlr7Q=" crossorigin="anonymous"></script>
+      <script type="text/javascript" src="./js/dicepass.js" integrity="sha256-BZL8TY+R+j4rHZ3paNQU1lD3sDWXuSR01zMZgI41OeM=" crossorigin="anonymous"></script>
+      <script type="text/javascript" src="./js/vendor/isaac.js" integrity="sha256-k1iOEUzULNKQya/OGpiKGUKRIDwfRYcv1kptXt6/8r4=" crossorigin="anonymous"></script>
+      <script type="text/javascript" src="./js/main.js" integrity="sha256-5gAGxlXjkyvK2dD/YanEPzGBGi0EjmbQfAXSkJSWCFw=" crossorigin="anonymous"></script>
     </body>
 </html>


### PR DESCRIPTION
SRI is a W3C recommendation to ensure that clients requesting subresources are getting the data correctly. The specification can be read at https://www.w3.org/TR/SRI/. Browser support is limited, with about 70% support. However, browsers that do not support SRI should silently ingore it.

This commit adds SRI to the projects hosted CSS and JS using SHA-256. This does remove the ability to run the HTML "offline". Instead, the code will be needed to be served out of a web server, even if the webserver is 127.0.0.1.